### PR TITLE
Add obstacle and power-up script stubs

### DIFF
--- a/Assets/Scripts/Managers/BuffController.cs
+++ b/Assets/Scripts/Managers/BuffController.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tracks active buffs on the player.
+/// </summary>
+public class BuffController : MonoBehaviour
+{
+    private readonly List<IBuff> activeBuffs = new List<IBuff>();
+
+    public void AddBuff(IBuff buff)
+    {
+        buff.Apply(this);
+        activeBuffs.Add(buff);
+    }
+
+    public void RemoveBuff(IBuff buff)
+    {
+        buff.Remove(this);
+        activeBuffs.Remove(buff);
+    }
+}
+
+public interface IBuff
+{
+    void Apply(BuffController controller);
+    void Remove(BuffController controller);
+}

--- a/Assets/Scripts/Managers/ComboSystem.cs
+++ b/Assets/Scripts/Managers/ComboSystem.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks combos based on successive successful actions.
+/// </summary>
+public class ComboSystem : MonoBehaviour
+{
+    public float resetTime = 2f;
+    private int combo = 0;
+    private float timer;
+
+    void Update()
+    {
+        if (combo > 0)
+        {
+            timer += Time.deltaTime;
+            if (timer > resetTime)
+            {
+                combo = 0;
+                timer = 0;
+            }
+        }
+    }
+
+    public void RegisterAction()
+    {
+        combo++;
+        timer = 0;
+    }
+
+    public int CurrentCombo => combo;
+}

--- a/Assets/Scripts/Managers/EconomyManager.cs
+++ b/Assets/Scripts/Managers/EconomyManager.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks coins and handles purchases.
+/// </summary>
+public class EconomyManager : MonoBehaviour
+{
+    private int coins;
+
+    public void AddCoins(int amount)
+    {
+        coins += amount;
+    }
+
+    public bool Purchase(int cost)
+    {
+        if (coins >= cost)
+        {
+            coins -= cost;
+            return true;
+        }
+        return false;
+    }
+
+    public int Coins => coins;
+}

--- a/Assets/Scripts/Managers/LevelManager.cs
+++ b/Assets/Scripts/Managers/LevelManager.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+/// <summary>
+/// Controls level difficulty via curves.
+/// </summary>
+public class LevelManager : MonoBehaviour
+{
+    public AnimationCurve speedCurve = AnimationCurve.Linear(0, 1, 60, 3);
+    private float elapsed;
+
+    void Update()
+    {
+        elapsed += Time.deltaTime;
+    }
+
+    public float CurrentSpeedMultiplier()
+    {
+        return speedCurve.Evaluate(elapsed);
+    }
+}

--- a/Assets/Scripts/Managers/ScoreManager.cs
+++ b/Assets/Scripts/Managers/ScoreManager.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks player score and combos.
+/// </summary>
+public class ScoreManager : MonoBehaviour
+{
+    public ComboSystem combo;
+    private int score;
+
+    public void AddScore(int baseValue)
+    {
+        int mult = 1;
+        if (combo != null)
+        {
+            combo.RegisterAction();
+            mult = Mathf.Max(1, combo.CurrentCombo);
+        }
+        score += baseValue * mult;
+    }
+
+    public int CurrentScore => score;
+}

--- a/Assets/Scripts/Obstacles/Frog.cs
+++ b/Assets/Scripts/Obstacles/Frog.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Frog that hops periodically and damages the player on contact.
+/// </summary>
+public class Frog : MonoBehaviour
+{
+    public float hopForce = 5f;
+    public float hopInterval = 2f;
+    public int damage = 1;
+    private Rigidbody2D rb;
+
+    void Start()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        InvokeRepeating(nameof(Hop), 0, hopInterval);
+    }
+
+    void Hop()
+    {
+        rb.velocity = Vector2.up * hopForce;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/Insect.cs
+++ b/Assets/Scripts/Obstacles/Insect.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple insect AI that chases the player horizontally.
+/// </summary>
+public class Insect : MonoBehaviour
+{
+    public float speed = 2f;
+    public int damage = 1;
+    private Transform target;
+
+    void Start()
+    {
+        GameObject player = GameObject.FindWithTag("Player");
+        if (player != null)
+        {
+            target = player.transform;
+        }
+    }
+
+    void Update()
+    {
+        if (target == null) return;
+        Vector3 dir = (target.position - transform.position).normalized;
+        transform.position += dir * speed * Time.deltaTime;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/LaserBeam.cs
+++ b/Assets/Scripts/Obstacles/LaserBeam.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Laser beam that sweeps across the screen after a telegraph.
+/// </summary>
+public class LaserBeam : MonoBehaviour
+{
+    public LineRenderer renderer;
+    public float warningDuration = 1.0f;
+    public float activeDuration = 2.0f;
+    public int damage = 1;
+
+    private void Start()
+    {
+        StartCoroutine(FireRoutine());
+    }
+
+    private System.Collections.IEnumerator FireRoutine()
+    {
+        renderer.enabled = true; // telegraph
+        yield return new WaitForSeconds(warningDuration);
+
+        float timer = activeDuration;
+        while (timer > 0)
+        {
+            timer -= Time.deltaTime;
+            yield return null;
+        }
+
+        Destroy(gameObject);
+    }
+
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/Mine.cs
+++ b/Assets/Scripts/Obstacles/Mine.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple mine that explodes when the player gets close.
+/// Shows a telegraph before dealing damage.
+/// </summary>
+public class Mine : MonoBehaviour
+{
+    public float warningDuration = 1.0f;
+    public int damage = 1;
+    private bool armed = false;
+
+    private void Start()
+    {
+        // Begin telegraph as soon as the mine becomes active
+        StartCoroutine(Telegraph());
+    }
+
+    private System.Collections.IEnumerator Telegraph()
+    {
+        yield return new WaitForSeconds(warningDuration);
+        armed = true;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (!armed) return;
+
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/RotatingPipe.cs
+++ b/Assets/Scripts/Obstacles/RotatingPipe.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+/// <summary>
+/// Rotating pipe that harms the player on contact.
+/// </summary>
+public class RotatingPipe : MonoBehaviour
+{
+    public float rotationSpeed = 45f;
+    public int damage = 1;
+
+    void Update()
+    {
+        transform.Rotate(0, 0, rotationSpeed * Time.deltaTime);
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/DoubleCoins.cs
+++ b/Assets/Scripts/PowerUps/DoubleCoins.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// Doubles coin collection for a duration.
+/// </summary>
+public class DoubleCoins : MonoBehaviour, IBuff
+{
+    public float duration = 5f;
+
+    public void Apply(BuffController controller)
+    {
+        // TODO: Double coin value
+        controller.StartCoroutine(Expire(controller));
+    }
+
+    private System.Collections.IEnumerator Expire(BuffController controller)
+    {
+        yield return new WaitForSeconds(duration);
+        controller.RemoveBuff(this);
+    }
+
+    public void Remove(BuffController controller)
+    {
+        // TODO: Restore coin value
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        BuffController buffs = collision.GetComponent<BuffController>();
+        if (buffs != null)
+        {
+            buffs.AddBuff(this);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/HealthPack.cs
+++ b/Assets/Scripts/PowerUps/HealthPack.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+/// <summary>
+/// Restores player health on pickup.
+/// </summary>
+public class HealthPack : MonoBehaviour
+{
+    public int amount = 1;
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        PlayerHealth health = collision.GetComponent<PlayerHealth>();
+        if (health != null)
+        {
+            health.Heal(amount);
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/Magnet.cs
+++ b/Assets/Scripts/PowerUps/Magnet.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+/// <summary>
+/// Pulls nearby coins toward the player.
+/// </summary>
+public class Magnet : MonoBehaviour, IBuff
+{
+    public float duration = 5f;
+    public float radius = 5f;
+
+    public void Apply(BuffController controller)
+    {
+        controller.StartCoroutine(Expire(controller));
+    }
+
+    private System.Collections.IEnumerator Expire(BuffController controller)
+    {
+        yield return new WaitForSeconds(duration);
+        controller.RemoveBuff(this);
+    }
+
+    public void Remove(BuffController controller)
+    {
+        // TODO: Remove magnet effect
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        BuffController buffs = collision.GetComponent<BuffController>();
+        if (buffs != null)
+        {
+            buffs.AddBuff(this);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/MonsterWard.cs
+++ b/Assets/Scripts/PowerUps/MonsterWard.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Temporarily prevents monsters from spawning.
+/// </summary>
+public class MonsterWard : MonoBehaviour, IBuff
+{
+    public float duration = 5f;
+
+    public void Apply(BuffController controller)
+    {
+        controller.StartCoroutine(Expire(controller));
+    }
+
+    private System.Collections.IEnumerator Expire(BuffController controller)
+    {
+        yield return new WaitForSeconds(duration);
+        controller.RemoveBuff(this);
+    }
+
+    public void Remove(BuffController controller)
+    {
+        // TODO: Resume spawning
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        BuffController buffs = collision.GetComponent<BuffController>();
+        if (buffs != null)
+        {
+            buffs.AddBuff(this);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/ShieldBoost.cs
+++ b/Assets/Scripts/PowerUps/ShieldBoost.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Grants temporary invulnerability.
+/// </summary>
+public class ShieldBoost : MonoBehaviour, IBuff
+{
+    public float duration = 5f;
+
+    public void Apply(BuffController controller)
+    {
+        controller.StartCoroutine(Expire(controller));
+    }
+
+    private System.Collections.IEnumerator Expire(BuffController controller)
+    {
+        yield return new WaitForSeconds(duration);
+        controller.RemoveBuff(this);
+    }
+
+    public void Remove(BuffController controller)
+    {
+        // TODO: Remove invulnerability
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        BuffController buffs = collision.GetComponent<BuffController>();
+        if (buffs != null)
+        {
+            buffs.AddBuff(this);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/PowerUps/SlowTime.cs
+++ b/Assets/Scripts/PowerUps/SlowTime.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+/// <summary>
+/// Slows down time for a short duration.
+/// </summary>
+public class SlowTime : MonoBehaviour, IBuff
+{
+    public float duration = 5f;
+    public float timeScale = 0.5f;
+
+    public void Apply(BuffController controller)
+    {
+        Time.timeScale = timeScale;
+        controller.StartCoroutine(Expire(controller));
+    }
+
+    private System.Collections.IEnumerator Expire(BuffController controller)
+    {
+        yield return new WaitForSecondsRealtime(duration);
+        controller.RemoveBuff(this);
+    }
+
+    public void Remove(BuffController controller)
+    {
+        Time.timeScale = 1f;
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        BuffController buffs = collision.GetComponent<BuffController>();
+        if (buffs != null)
+        {
+            buffs.AddBuff(this);
+            gameObject.SetActive(false);
+        }
+    }
+}

--- a/Assets/Scripts/Spawning/SpawnDirector.cs
+++ b/Assets/Scripts/Spawning/SpawnDirector.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+/// <summary>
+/// Chooses spawners to activate based on weighted random and level scaling.
+/// </summary>
+public class SpawnDirector : MonoBehaviour
+{
+    [System.Serializable]
+    public class SpawnEntry
+    {
+        public Spawner spawner;
+        public float weight = 1f;
+    }
+
+    public SpawnEntry[] entries;
+    public AnimationCurve levelCurve = AnimationCurve.Linear(0, 1, 60, 5);
+    private float elapsed;
+
+    void Update()
+    {
+        elapsed += Time.deltaTime;
+    }
+
+    public void Spawn()
+    {
+        if (entries == null || entries.Length == 0) return;
+        float total = 0f;
+        foreach (var e in entries) total += e.weight;
+        float choice = Random.Range(0, total);
+        foreach (var e in entries)
+        {
+            if (choice < e.weight)
+            {
+                float level = levelCurve.Evaluate(elapsed);
+                for (int i = 0; i < level; i++)
+                {
+                    e.spawner.Spawn();
+                }
+                return;
+            }
+            choice -= e.weight;
+        }
+    }
+}

--- a/Assets/Scripts/Spawning/Spawner.cs
+++ b/Assets/Scripts/Spawning/Spawner.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+/// <summary>
+/// Spawns a random prefab from a list at fixed intervals.
+/// </summary>
+public class Spawner : MonoBehaviour
+{
+    public GameObject[] prefabs;
+    public float interval = 3f;
+    public Transform parent;
+
+    void Start()
+    {
+        InvokeRepeating(nameof(Spawn), interval, interval);
+    }
+
+    public void Spawn()
+    {
+        if (prefabs == null || prefabs.Length == 0) return;
+        GameObject prefab = prefabs[Random.Range(0, prefabs.Length)];
+        Instantiate(prefab, transform.position, Quaternion.identity, parent);
+    }
+}


### PR DESCRIPTION
## Summary
- add initial obstacle behaviours like Mine, LaserBeam, RotatingPipe, Insect, and Frog
- implement basic spawner system with weighted SpawnDirector
- introduce power-up stubs and foundational managers for buffs, levels, score, combos, and economy

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a752410c8883308d24d91353736994