### PR TITLE
feat: add core gameplay skeleton

### DIFF
--- a/Assets/_Game/Scripts/Ads/Adapters/AdmobAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/AdmobAdapter.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Stub implementation of the Google AdMob adapter.
+/// </summary>
+public class AdmobAdapter : IAdNetworkAdapter
+{
+    public event Action OnAdLoaded;
+    public event Action<string> OnAdFailed;
+    public event Action OnAdShown;
+    public event Action OnAdClosed;
+    public event Action OnAdRewarded;
+
+    public bool IsInterstitialReady => false;
+    public bool IsRewardedReady => false;
+
+    public void Initialize(ConsentState consent)
+    {
+        Debug.Log($"[Admob] Initialize with consent {consent}");
+    }
+
+    public void LoadInterstitial()
+    {
+        Debug.Log("[Admob] Load interstitial");
+    }
+
+    public void ShowInterstitial()
+    {
+        Debug.Log("[Admob] Show interstitial");
+    }
+
+    public void LoadRewarded()
+    {
+        Debug.Log("[Admob] Load rewarded");
+    }
+
+    public void ShowRewarded()
+    {
+        Debug.Log("[Admob] Show rewarded");
+    }
+
+    public void ShowBanner()
+    {
+        Debug.Log("[Admob] Show banner");
+    }
+
+    public void HideBanner()
+    {
+        Debug.Log("[Admob] Hide banner");
+    }
+}

--- a/Assets/_Game/Scripts/Ads/Adapters/LevelPlayAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/LevelPlayAdapter.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Stub implementation for Unity LevelPlay (ironSource) adapter.
+/// </summary>
+public class LevelPlayAdapter : IAdNetworkAdapter
+{
+    public event Action OnAdLoaded;
+    public event Action<string> OnAdFailed;
+    public event Action OnAdShown;
+    public event Action OnAdClosed;
+    public event Action OnAdRewarded;
+
+    public bool IsInterstitialReady => false;
+    public bool IsRewardedReady => false;
+
+    public void Initialize(ConsentState consent)
+    {
+        Debug.Log($"[LevelPlay] Initialize with consent {consent}");
+    }
+
+    public void LoadInterstitial()
+    {
+        Debug.Log("[LevelPlay] Load interstitial");
+    }
+
+    public void ShowInterstitial()
+    {
+        Debug.Log("[LevelPlay] Show interstitial");
+    }
+
+    public void LoadRewarded()
+    {
+        Debug.Log("[LevelPlay] Load rewarded");
+    }
+
+    public void ShowRewarded()
+    {
+        Debug.Log("[LevelPlay] Show rewarded");
+    }
+
+    public void ShowBanner()
+    {
+        Debug.Log("[LevelPlay] Show banner");
+    }
+
+    public void HideBanner()
+    {
+        Debug.Log("[LevelPlay] Hide banner");
+    }
+}

--- a/Assets/_Game/Scripts/Ads/Adapters/UnityMediationAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/UnityMediationAdapter.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Stub implementation for Unity Mediation adapter.
+/// </summary>
+public class UnityMediationAdapter : IAdNetworkAdapter
+{
+    public event Action OnAdLoaded;
+    public event Action<string> OnAdFailed;
+    public event Action OnAdShown;
+    public event Action OnAdClosed;
+    public event Action OnAdRewarded;
+
+    public bool IsInterstitialReady => false;
+    public bool IsRewardedReady => false;
+
+    public void Initialize(ConsentState consent)
+    {
+        Debug.Log($"[UnityMediation] Initialize with consent {consent}");
+    }
+
+    public void LoadInterstitial()
+    {
+        Debug.Log("[UnityMediation] Load interstitial");
+    }
+
+    public void ShowInterstitial()
+    {
+        Debug.Log("[UnityMediation] Show interstitial");
+    }
+
+    public void LoadRewarded()
+    {
+        Debug.Log("[UnityMediation] Load rewarded");
+    }
+
+    public void ShowRewarded()
+    {
+        Debug.Log("[UnityMediation] Show rewarded");
+    }
+
+    public void ShowBanner()
+    {
+        Debug.Log("[UnityMediation] Show banner");
+    }
+
+    public void HideBanner()
+    {
+        Debug.Log("[UnityMediation] Hide banner");
+    }
+}

--- a/Assets/_Game/Scripts/Ads/AdsManager.cs
+++ b/Assets/_Game/Scripts/Ads/AdsManager.cs
@@ -1,0 +1,124 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Central manager that coordinates ad display and enforces policy caps.
+/// </summary>
+public class AdsManager : MonoBehaviour
+{
+    [SerializeField] private AdPolicy m_policy;
+    [SerializeField] private bool m_testMode = true;
+
+    private IAdNetworkAdapter m_adapter;
+    private float m_lastInterstitialTime;
+    private int m_runsSinceInterstitial;
+    private int m_sessionInterstitialCount;
+    private bool m_skipInterstitial;
+
+    /// <summary>
+    /// Initialize the ads system using the provided adapter.
+    /// </summary>
+    /// <param name="adapter">Concrete network adapter.</param>
+    /// <param name="consent">User consent state.</param>
+    public void Initialize(IAdNetworkAdapter adapter, ConsentState consent)
+    {
+        m_adapter = adapter;
+        m_adapter.Initialize(consent);
+        m_adapter.LoadInterstitial();
+        m_adapter.LoadRewarded();
+    }
+
+    /// <summary>
+    /// Should be called whenever a new run starts.
+    /// </summary>
+    public void NotifyRunStarted()
+    {
+        m_runsSinceInterstitial++;
+    }
+
+    /// <summary>
+    /// Try to show an interstitial respecting frequency caps.
+    /// </summary>
+    public void TryShowInterstitial()
+    {
+        if (m_policy == null || m_adapter == null) return;
+        if (m_skipInterstitial)
+        {
+            m_skipInterstitial = false;
+            return;
+        }
+        if (m_runsSinceInterstitial < m_policy.showInterstitialEveryNRuns) return;
+        if (Time.realtimeSinceStartup - m_lastInterstitialTime < m_policy.minSecondsBetweenInterstitial) return;
+        if (m_sessionInterstitialCount >= m_policy.maxInterstitialsPerSession) return;
+        if (!m_adapter.IsInterstitialReady) return;
+        m_adapter.ShowInterstitial();
+        m_adapter.LoadInterstitial();
+        m_lastInterstitialTime = Time.realtimeSinceStartup;
+        m_sessionInterstitialCount++;
+        m_runsSinceInterstitial = 0;
+    }
+
+    /// <summary>
+    /// Try to show a rewarded ad and invoke callback on reward.
+    /// </summary>
+    public void TryShowRewarded(Action onReward)
+    {
+        if (m_adapter == null || !m_adapter.IsRewardedReady) return;
+        void RewardHandler()
+        {
+            onReward?.Invoke();
+            m_adapter.OnAdRewarded -= RewardHandler;
+            m_skipInterstitial = true;
+        }
+        m_adapter.OnAdRewarded += RewardHandler;
+        m_adapter.ShowRewarded();
+        m_adapter.LoadRewarded();
+    }
+
+    /// <summary>
+    /// Show banner if policy allows it.
+    /// </summary>
+    public void ShowBanner()
+    {
+        if (m_policy != null && m_policy.bannerEnabled)
+            m_adapter?.ShowBanner();
+    }
+
+    /// <summary>
+    /// Hide banner if visible.
+    /// </summary>
+    public void HideBanner()
+    {
+        m_adapter?.HideBanner();
+    }
+
+    /// <summary>
+    /// Apply ad-free purchase disabling all ads.
+    /// </summary>
+    public void ApplyAdFree()
+    {
+        m_policy = null;
+        m_adapter?.HideBanner();
+    }
+}
+
+/// <summary>
+/// Scriptable object defining ad frequency and placements.
+/// </summary>
+[CreateAssetMenu(menuName = "_Game/Ads/AdPolicy")]
+public class AdPolicy : ScriptableObject
+{
+    [Tooltip("Show interstitial every N runs."), Min(1)]
+    public int showInterstitialEveryNRuns = 2;
+
+    [Tooltip("Minimum seconds between interstitial impressions."), Min(0f)]
+    public float minSecondsBetweenInterstitial = 90f;
+
+    [Tooltip("Maximum interstitials per session."), Min(0)]
+    public int maxInterstitialsPerSession = 2;
+
+    public bool bannerEnabled = true;
+    public bool rewardedContinueEnabled = true;
+    public bool rewardedDoubleCoinsEnabled = true;
+    public bool rewardedStartPowerUpEnabled = true;
+}

--- a/Assets/_Game/Scripts/Ads/IAdNetworkAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/IAdNetworkAdapter.cs
@@ -1,0 +1,88 @@
+using System;
+
+/// <summary>
+/// Interface for ad network adapters.
+/// </summary>
+public interface IAdNetworkAdapter
+{
+    /// <summary>
+    /// Raised when an ad is successfully loaded.
+    /// </summary>
+    event Action OnAdLoaded;
+
+    /// <summary>
+    /// Raised when an ad fails to load.
+    /// </summary>
+    event Action<string> OnAdFailed;
+
+    /// <summary>
+    /// Raised when an ad is shown to the user.
+    /// </summary>
+    event Action OnAdShown;
+
+    /// <summary>
+    /// Raised when the ad is closed by the user.
+    /// </summary>
+    event Action OnAdClosed;
+
+    /// <summary>
+    /// Raised when a reward is earned from a rewarded ad.
+    /// </summary>
+    event Action OnAdRewarded;
+
+    /// <summary>
+    /// Initialize the ad network adapter with consent information.
+    /// </summary>
+    /// <param name="consent">Consent state of the user.</param>
+    void Initialize(ConsentState consent);
+
+    /// <summary>
+    /// Begin loading an interstitial ad.
+    /// </summary>
+    void LoadInterstitial();
+
+    /// <summary>
+    /// Indicates whether an interstitial ad is ready to be shown.
+    /// </summary>
+    bool IsInterstitialReady { get; }
+
+    /// <summary>
+    /// Show the interstitial ad if ready.
+    /// </summary>
+    void ShowInterstitial();
+
+    /// <summary>
+    /// Begin loading a rewarded ad.
+    /// </summary>
+    void LoadRewarded();
+
+    /// <summary>
+    /// Indicates whether a rewarded ad is ready to be shown.
+    /// </summary>
+    bool IsRewardedReady { get; }
+
+    /// <summary>
+    /// Show the rewarded ad if ready.
+    /// </summary>
+    void ShowRewarded();
+
+    /// <summary>
+    /// Show a banner ad.
+    /// </summary>
+    void ShowBanner();
+
+    /// <summary>
+    /// Hide the banner ad if visible.
+    /// </summary>
+    void HideBanner();
+}
+
+/// <summary>
+/// Enumeration for user consent states.
+/// </summary>
+public enum ConsentState
+{
+    Unknown,
+    Accepted,
+    Rejected
+}

--- a/Assets/_Game/Scripts/Common/IDamageDealer.cs
+++ b/Assets/_Game/Scripts/Common/IDamageDealer.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+/// <summary>
+/// Provides damage information for collision handlers.
+/// </summary>
+public interface IDamageDealer
+{
+    int Damage { get; }
+}

--- a/Assets/_Game/Scripts/Common/IDamageable.cs
+++ b/Assets/_Game/Scripts/Common/IDamageable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+/// <summary>
+/// Represents an object that can receive damage.
+/// </summary>
+public interface IDamageable
+{
+    void TakeDamage(int amount);
+}

--- a/Assets/_Game/Scripts/Common/IPooled.cs
+++ b/Assets/_Game/Scripts/Common/IPooled.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+/// <summary>
+/// Interface for pooled objects.
+/// </summary>
+public interface IPooled
+{
+    void OnSpawned();
+    void OnDespawned();
+}

--- a/Assets/_Game/Scripts/Common/IResettable.cs
+++ b/Assets/_Game/Scripts/Common/IResettable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+/// <summary>
+/// Resets an object's state for pooling or game restarts.
+/// </summary>
+public interface IResettable
+{
+    void ResetState();
+}

--- a/Assets/_Game/Scripts/Entities/Coin.cs
+++ b/Assets/_Game/Scripts/Entities/Coin.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Simple coin collectible.
+/// </summary>
+public class Coin : MonoBehaviour, IPooled
+{
+    [SerializeField] private int m_value = 1;
+
+    public event Action<int> OnCollected;
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+            Collect();
+    }
+
+    private void Collect()
+    {
+        OnCollected?.Invoke(m_value);
+        gameObject.SetActive(false);
+    }
+
+    public void OnSpawned() { }
+    public void OnDespawned() { }
+}

--- a/Assets/_Game/Scripts/Managers/ConsentManager.cs
+++ b/Assets/_Game/Scripts/Managers/ConsentManager.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles user consent flows such as GDPR and ATT prompts.
+/// </summary>
+public class ConsentManager : MonoBehaviour
+{
+    public ConsentState CurrentConsent { get; private set; } = ConsentState.Unknown;
+
+    /// <summary>
+    /// Simulate displaying consent dialogs and storing the result.
+    /// </summary>
+    public void RequestConsent()
+    {
+        // In a production game this would display native dialogs.
+        CurrentConsent = ConsentState.Accepted;
+    }
+}

--- a/Assets/_Game/Scripts/Managers/DifficultyCurve.cs
+++ b/Assets/_Game/Scripts/Managers/DifficultyCurve.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+
+/// <summary>
+/// Defines per-level curves for difficulty scaling.
+/// </summary>
+[CreateAssetMenu(menuName = "_Game/Config/DifficultyCurve")]
+public class DifficultyCurve : ScriptableObject
+{
+    public AnimationCurve scrollSpeed = AnimationCurve.Linear(0, 1, 10, 5);
+    public AnimationCurve obstacleSpawnInterval = AnimationCurve.Linear(0, 2, 10, 0.5f);
+}

--- a/Assets/_Game/Scripts/Managers/GameManager.cs
+++ b/Assets/_Game/Scripts/Managers/GameManager.cs
@@ -1,0 +1,63 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Handles core game state transitions and scoring.
+/// </summary>
+public class GameManager : MonoBehaviour
+{
+    public enum GameState { Menu, Countdown, Playing, Paused, GameOver }
+
+    [SerializeField] private SaveSystem m_saveSystem;
+
+    public GameState State { get; private set; } = GameState.Menu;
+
+    public event Action OnRunStarted;
+    public event Action OnRunEnded;
+    public event Action<int> OnScoreChanged;
+    public event Action<int> OnBestScoreUpdated;
+
+    private int m_score;
+
+    /// <summary>
+    /// Begin a new run.
+    /// </summary>
+    public void StartRun()
+    {
+        m_score = 0;
+        State = GameState.Playing;
+        OnRunStarted?.Invoke();
+    }
+
+    /// <summary>
+    /// End the current run.
+    /// </summary>
+    public void EndRun()
+    {
+        State = GameState.GameOver;
+        OnRunEnded?.Invoke();
+        if (m_score > m_saveSystem.BestScore)
+        {
+            m_saveSystem.BestScore = m_score;
+            OnBestScoreUpdated?.Invoke(m_score);
+        }
+        m_saveSystem.Save();
+    }
+
+    /// <summary>
+    /// Add to current score and notify listeners.
+    /// </summary>
+    public void AddScore(int amount)
+    {
+        m_score += amount;
+        OnScoreChanged?.Invoke(m_score);
+    }
+
+    /// <summary>
+    /// Load saves on awake.
+    /// </summary>
+    private void Awake()
+    {
+        m_saveSystem?.Load();
+    }
+}

--- a/Assets/_Game/Scripts/Managers/LevelManager.cs
+++ b/Assets/_Game/Scripts/Managers/LevelManager.cs
@@ -1,0 +1,48 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Tracks level progression based on distance traveled.
+/// </summary>
+public class LevelManager : MonoBehaviour
+{
+    [SerializeField] private DifficultyCurve m_curve;
+    [SerializeField] private float m_distancePerLevel = 100f;
+
+    private int m_level;
+    private float m_distance;
+
+    public int Level => m_level;
+
+    public event Action<int> OnLevelChanged;
+
+    /// <summary>
+    /// Add distance and update level accordingly.
+    /// </summary>
+    public void AddDistance(float delta)
+    {
+        m_distance += delta;
+        int newLevel = Mathf.FloorToInt(m_distance / m_distancePerLevel);
+        if (newLevel > m_level)
+        {
+            m_level = newLevel;
+            OnLevelChanged?.Invoke(m_level);
+        }
+    }
+
+    /// <summary>
+    /// Gets current scroll speed from difficulty curve.
+    /// </summary>
+    public float GetScrollSpeed()
+    {
+        return m_curve != null ? m_curve.scrollSpeed.Evaluate(m_level) : 0f;
+    }
+
+    /// <summary>
+    /// Gets obstacle spawn interval from difficulty curve.
+    /// </summary>
+    public float GetObstacleInterval()
+    {
+        return m_curve != null ? m_curve.obstacleSpawnInterval.Evaluate(m_level) : 1f;
+    }
+}

--- a/Assets/_Game/Scripts/Managers/SaveSystem.cs
+++ b/Assets/_Game/Scripts/Managers/SaveSystem.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using UnityEngine;
+
+/// <summary>
+/// Simple JSON save system backed by PlayerPrefs.
+/// </summary>
+public class SaveSystem : MonoBehaviour
+{
+    private const string c_SaveKey = "_game_save";
+
+    [System.Serializable]
+    private class SaveData
+    {
+        public int bestScore;
+        public int totalCoins;
+        public bool adFree;
+    }
+
+    private SaveData m_data = new SaveData();
+
+    /// <summary>
+    /// Load persistent data from PlayerPrefs.
+    /// </summary>
+    public void Load()
+    {
+        if (PlayerPrefs.HasKey(c_SaveKey))
+        {
+            string json = PlayerPrefs.GetString(c_SaveKey);
+            m_data = JsonUtility.FromJson<SaveData>(json);
+        }
+    }
+
+    /// <summary>
+    /// Save current data to PlayerPrefs.
+    /// </summary>
+    public void Save()
+    {
+        string json = JsonUtility.ToJson(m_data);
+        PlayerPrefs.SetString(c_SaveKey, json);
+        PlayerPrefs.Save();
+    }
+
+    /// <summary>
+    /// Gets or sets the best score.
+    /// </summary>
+    public int BestScore
+    {
+        get => m_data.bestScore;
+        set => m_data.bestScore = Mathf.Max(m_data.bestScore, value);
+    }
+
+    /// <summary>
+    /// Total accumulated coins.
+    /// </summary>
+    public int TotalCoins
+    {
+        get => m_data.totalCoins;
+        set => m_data.totalCoins = value;
+    }
+
+    /// <summary>
+    /// Returns true if the player purchased ad removal.
+    /// </summary>
+    public bool AdFree
+    {
+        get => m_data.adFree;
+        set => m_data.adFree = value;
+    }
+}

--- a/Assets/_Game/Scripts/Player/BuffController.cs
+++ b/Assets/_Game/Scripts/Player/BuffController.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Handles timed player buffs.
+/// </summary>
+public class BuffController : MonoBehaviour
+{
+    public enum BuffType { Shield, MonsterWard, Magnet, DoubleCoins, SlowTime }
+
+    private readonly Dictionary<BuffType, float> m_active = new Dictionary<BuffType, float>();
+
+    public event Action<BuffType> OnBuffStarted;
+    public event Action<BuffType> OnBuffEnded;
+
+    /// <summary>
+    /// Apply a buff for a duration in seconds.
+    /// </summary>
+    public void Apply(BuffType type, float duration)
+    {
+        float end = Time.time + duration;
+        if (m_active.ContainsKey(type))
+            m_active[type] = end;
+        else
+        {
+            m_active.Add(type, end);
+            OnBuffStarted?.Invoke(type);
+        }
+    }
+
+    private void Update()
+    {
+        if (m_active.Count == 0) return;
+        var ended = new List<BuffType>();
+        foreach (var kvp in m_active)
+        {
+            if (Time.time >= kvp.Value)
+                ended.Add(kvp.Key);
+        }
+        foreach (var type in ended)
+        {
+            m_active.Remove(type);
+            OnBuffEnded?.Invoke(type);
+        }
+    }
+
+    /// <summary>
+    /// Check if the buff is active.
+    /// </summary>
+    public bool Has(BuffType type) => m_active.ContainsKey(type);
+}

--- a/Assets/_Game/Scripts/Player/Health.cs
+++ b/Assets/_Game/Scripts/Player/Health.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Manages player health and damage.
+/// </summary>
+public class Health : MonoBehaviour, IDamageable
+{
+    [SerializeField] private int m_maxHealth = 3;
+
+    private int m_current;
+
+    public int MaxHealth => m_maxHealth;
+    public int Current => m_current;
+
+    public event Action<int> OnHealthChanged;
+    public event Action OnDied;
+
+    private void Awake()
+    {
+        m_current = m_maxHealth;
+    }
+
+    /// <summary>
+    /// Apply damage to the entity.
+    /// </summary>
+    public void TakeDamage(int amount)
+    {
+        m_current = Mathf.Max(0, m_current - amount);
+        OnHealthChanged?.Invoke(m_current);
+        if (m_current == 0)
+            OnDied?.Invoke();
+    }
+
+    /// <summary>
+    /// Heal up to max health.
+    /// </summary>
+    public void Heal(int amount)
+    {
+        m_current = Mathf.Min(m_maxHealth, m_current + amount);
+        OnHealthChanged?.Invoke(m_current);
+    }
+
+    /// <summary>
+    /// Reset health to max.
+    /// </summary>
+    public void ResetHealth()
+    {
+        m_current = m_maxHealth;
+        OnHealthChanged?.Invoke(m_current);
+    }
+}

--- a/Assets/_Game/Scripts/Player/PlayerController.cs
+++ b/Assets/_Game/Scripts/Player/PlayerController.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles player input and movement.
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D))]
+public class PlayerController : MonoBehaviour
+{
+    [SerializeField] private float m_flapForce = 5f;
+    [SerializeField] private float m_verticalClamp = 4f;
+    [SerializeField] private Rigidbody2D m_body;
+    [SerializeField] private Health m_health;
+    [SerializeField] private BuffController m_buffs;
+
+    private void Awake()
+    {
+        if (m_body == null)
+            m_body = GetComponent<Rigidbody2D>();
+    }
+
+    private void Update()
+    {
+        if (Input.GetMouseButtonDown(0) || Input.GetKeyDown(KeyCode.Space))
+            Flap();
+    }
+
+    private void FixedUpdate()
+    {
+        Vector2 pos = m_body.position;
+        pos.y = Mathf.Clamp(pos.y, -m_verticalClamp, m_verticalClamp);
+        m_body.position = pos;
+    }
+
+    private void Flap()
+    {
+        m_body.velocity = new Vector2(m_body.velocity.x, 0f);
+        m_body.AddForce(Vector2.up * m_flapForce, ForceMode2D.Impulse);
+    }
+}

--- a/Assets/_Game/Scripts/Utilities/ObjectPooler.cs
+++ b/Assets/_Game/Scripts/Utilities/ObjectPooler.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Generic object pooler for frequently spawned objects.
+/// </summary>
+public class ObjectPooler : MonoBehaviour
+{
+    [System.Serializable]
+    public class Pool
+    {
+        public string key;
+        public GameObject prefab;
+        public int initialSize = 5;
+    }
+
+    [SerializeField] private Pool[] m_pools;
+    private readonly Dictionary<string, Queue<GameObject>> m_poolMap = new Dictionary<string, Queue<GameObject>>();
+
+    private void Awake()
+    {
+        foreach (var pool in m_pools)
+        {
+            var queue = new Queue<GameObject>();
+            for (int i = 0; i < pool.initialSize; i++)
+                queue.Enqueue(Create(pool));
+            m_poolMap.Add(pool.key, queue);
+        }
+    }
+
+    private GameObject Create(Pool pool)
+    {
+        var obj = Instantiate(pool.prefab);
+        obj.SetActive(false);
+        return obj;
+    }
+
+    /// <summary>
+    /// Spawn object by key.
+    /// </summary>
+    public GameObject Spawn(string key, Vector3 position, Quaternion rotation)
+    {
+        if (!m_poolMap.TryGetValue(key, out var queue))
+            return null;
+        GameObject obj = queue.Count > 0 ? queue.Dequeue() : Create(System.Array.Find(m_pools, p => p.key == key));
+        obj.transform.SetPositionAndRotation(position, rotation);
+        obj.SetActive(true);
+        if (obj.TryGetComponent<IPooled>(out var pooled))
+            pooled.OnSpawned();
+        return obj;
+    }
+
+    /// <summary>
+    /// Despawn object back to pool.
+    /// </summary>
+    public void Despawn(string key, GameObject obj)
+    {
+        if (!m_poolMap.TryGetValue(key, out var queue))
+            return;
+        if (obj.TryGetComponent<IPooled>(out var pooled))
+            pooled.OnDespawned();
+        obj.SetActive(false);
+        queue.Enqueue(obj);
+    }
+}

--- a/Assets/_Game/Scripts/Utilities/RandomService.cs
+++ b/Assets/_Game/Scripts/Utilities/RandomService.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Centralized random number provider with deterministic seed support.
+/// </summary>
+public class RandomService : MonoBehaviour
+{
+    [SerializeField] private int m_seed = 0;
+    private System.Random m_random;
+
+    private void Awake()
+    {
+        m_random = m_seed == 0 ? new System.Random() : new System.Random(m_seed);
+    }
+
+    /// <summary>
+    /// Re-seed the random generator.
+    /// </summary>
+    public void SetSeed(int seed)
+    {
+        m_seed = seed;
+        m_random = new System.Random(m_seed);
+    }
+
+    /// <summary>
+    /// Returns a value in [0,1).
+    /// </summary>
+    public float Value => (float)m_random.NextDouble();
+
+    /// <summary>
+    /// Weighted random selection from list.
+    /// </summary>
+    public T WeightedRandom<T>(IList<T> items, IList<float> weights)
+    {
+        if (items == null || weights == null || items.Count != weights.Count || items.Count == 0)
+            throw new ArgumentException("Invalid weights");
+        float total = 0f;
+        for (int i = 0; i < weights.Count; i++)
+            total += Mathf.Max(0f, weights[i]);
+        float roll = Value * total;
+        for (int i = 0; i < items.Count; i++)
+        {
+            roll -= Mathf.Max(0f, weights[i]);
+            if (roll <= 0f)
+                return items[i];
+        }
+        return items[items.Count - 1];
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# flappy-game
+# Flappy Game
+
+This repository contains a Unity project skeleton for a modern Flappy Bird–style game.
+It demonstrates an extensible architecture using ScriptableObjects, object pooling,
+and an ad mediation layer via `AdsManager` and pluggable `IAdNetworkAdapter` implementations.
+Core gameplay scaffolding is provided including managers, player components and utilities.
+The skeleton also includes a persistent save system and configurable ad policy for frequency-capped interstitial and rewarded ads.
+
+Project structure:
+
+```
+Assets/_Game/Scripts
+├── Ads
+│   ├── AdsManager.cs
+│   ├── IAdNetworkAdapter.cs
+│   └── Adapters
+│       ├── AdmobAdapter.cs
+│       ├── UnityMediationAdapter.cs
+│       └── LevelPlayAdapter.cs
+├── Managers
+│   ├── GameManager.cs
+│   ├── LevelManager.cs
+│   ├── SaveSystem.cs
+│   ├── DifficultyCurve.cs
+│   └── ConsentManager.cs
+├── Player
+│   ├── PlayerController.cs
+│   ├── Health.cs
+│   └── BuffController.cs
+├── Utilities
+│   ├── RandomService.cs
+│   └── ObjectPooler.cs
+├── Entities
+│   └── Coin.cs
+└── Common
+    ├── IDamageable.cs
+    ├── IDamageDealer.cs
+    ├── IPooled.cs
+    └── IResettable.cs
+```
+
+These scripts serve as a foundation for building out gameplay, spawning systems, UI and
+additional content.


### PR DESCRIPTION
## Summary
- scaffold core managers and player components for Flappy-style gameplay
- introduce ad mediation layer with policy caps and pluggable adapters
- add utilities for persistence, pooling, randomness, and buff handling
- document save system and ad policy in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f90d8e48330aa46c176ab53b305