### PR TITLE
Add basic UI menus and HUD

### DIFF
--- a/Assets/_Game/Scripts/Entities/Coin.cs
+++ b/Assets/_Game/Scripts/Entities/Coin.cs
@@ -19,6 +19,11 @@ public class Coin : MonoBehaviour, IPooled
     private void Collect()
     {
         OnCollected?.Invoke(m_value);
+
+        // Inform the GameManager of the coin pickup so HUD can update the count.
+        var gm = FindObjectOfType<GameManager>();
+        gm?.AddCoins(m_value);
+
         gameObject.SetActive(false);
     }
 

--- a/Assets/_Game/Scripts/Managers/GameManager.cs
+++ b/Assets/_Game/Scripts/Managers/GameManager.cs
@@ -5,19 +5,27 @@ using UnityEngine;
 /// Handles core game state transitions and scoring.
 /// </summary>
 public class GameManager : MonoBehaviour
-{
+{ 
     public enum GameState { Menu, Countdown, Playing, Paused, GameOver }
 
     [SerializeField] private SaveSystem m_saveSystem;
+
+    public static GameManager Instance { get; private set; }
 
     public GameState State { get; private set; } = GameState.Menu;
 
     public event Action OnRunStarted;
     public event Action OnRunEnded;
+    public event Action OnPaused;
+    public event Action OnResumed;
     public event Action<int> OnScoreChanged;
     public event Action<int> OnBestScoreUpdated;
+    public event Action<int> OnCoinsChanged;
+    public event Action<float> OnComboChanged;
 
     private int m_score;
+    private int m_coins;
+    private float m_combo;
 
     /// <summary>
     /// Begin a new run.
@@ -25,8 +33,13 @@ public class GameManager : MonoBehaviour
     public void StartRun()
     {
         m_score = 0;
+        m_coins = 0;
+        m_combo = 0f;
         State = GameState.Playing;
+        Time.timeScale = 1f;
         OnRunStarted?.Invoke();
+        OnCoinsChanged?.Invoke(m_coins);
+        OnComboChanged?.Invoke(m_combo);
     }
 
     /// <summary>
@@ -41,6 +54,7 @@ public class GameManager : MonoBehaviour
             m_saveSystem.BestScore = m_score;
             OnBestScoreUpdated?.Invoke(m_score);
         }
+        m_saveSystem.TotalCoins += m_coins;
         m_saveSystem.Save();
     }
 
@@ -54,10 +68,56 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
+    /// Add coins for the current run and notify listeners.
+    /// </summary>
+    public void AddCoins(int amount)
+    {
+        m_coins += amount;
+        OnCoinsChanged?.Invoke(m_coins);
+    }
+
+    /// <summary>
+    /// Update the current combo meter value.
+    /// </summary>
+    public void UpdateCombo(float value)
+    {
+        m_combo = value;
+        OnComboChanged?.Invoke(m_combo);
+    }
+
+    /// <summary>
+    /// Pause the game.
+    /// </summary>
+    public void Pause()
+    {
+        if (State != GameState.Playing) return;
+        State = GameState.Paused;
+        Time.timeScale = 0f;
+        OnPaused?.Invoke();
+    }
+
+    /// <summary>
+    /// Resume the game from pause.
+    /// </summary>
+    public void Resume()
+    {
+        if (State != GameState.Paused) return;
+        State = GameState.Playing;
+        Time.timeScale = 1f;
+        OnResumed?.Invoke();
+    }
+
+    /// <summary>
     /// Load saves on awake.
     /// </summary>
     private void Awake()
     {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
         m_saveSystem?.Load();
     }
 }

--- a/Assets/_Game/Scripts/Player/BuffController.cs
+++ b/Assets/_Game/Scripts/Player/BuffController.cs
@@ -11,7 +11,14 @@ public class BuffController : MonoBehaviour
 
     private readonly Dictionary<BuffType, float> m_active = new Dictionary<BuffType, float>();
 
-    public event Action<BuffType> OnBuffStarted;
+    /// <summary>
+    /// Invoked when a buff begins. The float parameter represents the duration in seconds.
+    /// </summary>
+    public event Action<BuffType, float> OnBuffStarted;
+
+    /// <summary>
+    /// Invoked when a buff expires.
+    /// </summary>
     public event Action<BuffType> OnBuffEnded;
 
     /// <summary>
@@ -21,11 +28,14 @@ public class BuffController : MonoBehaviour
     {
         float end = Time.time + duration;
         if (m_active.ContainsKey(type))
+        {
             m_active[type] = end;
+        }
         else
         {
             m_active.Add(type, end);
-            OnBuffStarted?.Invoke(type);
+            // Notify listeners with the total duration of the buff so UI timers can be displayed.
+            OnBuffStarted?.Invoke(type, duration);
         }
     }
 

--- a/Assets/_Game/Scripts/UI/CharacterSelectMenu.cs
+++ b/Assets/_Game/Scripts/UI/CharacterSelectMenu.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Character selection menu behaviour.
+/// </summary>
+public class CharacterSelectMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+
+    public void Back()
+    {
+        m_ui?.ShowMainMenu();
+    }
+}

--- a/Assets/_Game/Scripts/UI/HUDController.cs
+++ b/Assets/_Game/Scripts/UI/HUDController.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Controls the heads up display elements such as health, coins and buffs.
+/// </summary>
+public class HUDController : MonoBehaviour
+{
+    [SerializeField] private Text m_healthText;
+    [SerializeField] private Text m_coinText;
+    [SerializeField] private Text m_scoreText;
+    [SerializeField] private Text m_comboText;
+
+    [Serializable]
+    private class BuffTimer
+    {
+        public BuffController.BuffType type;
+        public Image fillImage;
+        [NonSerialized] public float duration;
+        [NonSerialized] public float start;
+        public void Begin(float d)
+        {
+            duration = d;
+            start = Time.time;
+            if (fillImage != null)
+                fillImage.gameObject.SetActive(true);
+        }
+        public void End()
+        {
+            if (fillImage != null)
+            {
+                fillImage.fillAmount = 0f;
+                fillImage.gameObject.SetActive(false);
+            }
+        }
+        public void Tick()
+        {
+            if (fillImage == null || !fillImage.gameObject.activeSelf) return;
+            float remaining = (start + duration) - Time.time;
+            fillImage.fillAmount = Mathf.Clamp01(remaining / duration);
+        }
+    }
+
+    [SerializeField] private BuffTimer[] m_buffTimers;
+    private Dictionary<BuffController.BuffType, BuffTimer> m_timerLookup;
+
+    private void Awake()
+    {
+        m_timerLookup = new Dictionary<BuffController.BuffType, BuffTimer>();
+        foreach (var timer in m_buffTimers)
+            m_timerLookup[timer.type] = timer;
+    }
+
+    private void Update()
+    {
+        if (m_timerLookup == null) return;
+        foreach (var timer in m_timerLookup.Values)
+            timer.Tick();
+    }
+
+    public void Bind(GameManager gm, Health health, BuffController buffs)
+    {
+        if (gm != null)
+        {
+            gm.OnScoreChanged += HandleScore;
+            gm.OnCoinsChanged += HandleCoins;
+            gm.OnComboChanged += HandleCombo;
+        }
+        if (health != null)
+            health.OnHealthChanged += HandleHealth;
+        if (buffs != null)
+        {
+            buffs.OnBuffStarted += HandleBuffStart;
+            buffs.OnBuffEnded += HandleBuffEnd;
+        }
+    }
+
+    private void HandleHealth(int value)
+    {
+        if (m_healthText != null)
+            m_healthText.text = $"HP: {value}";
+    }
+
+    private void HandleCoins(int value)
+    {
+        if (m_coinText != null)
+            m_coinText.text = $"Coins: {value}";
+    }
+
+    private void HandleScore(int value)
+    {
+        if (m_scoreText != null)
+            m_scoreText.text = $"Score: {value}";
+    }
+
+    private void HandleCombo(float value)
+    {
+        if (m_comboText != null)
+            m_comboText.text = $"Combo: {value:0.0}";
+    }
+
+    private void HandleBuffStart(BuffController.BuffType type, float duration)
+    {
+        if (m_timerLookup != null && m_timerLookup.TryGetValue(type, out var timer))
+            timer.Begin(duration);
+    }
+
+    private void HandleBuffEnd(BuffController.BuffType type)
+    {
+        if (m_timerLookup != null && m_timerLookup.TryGetValue(type, out var timer))
+            timer.End();
+    }
+}

--- a/Assets/_Game/Scripts/UI/MainMenu.cs
+++ b/Assets/_Game/Scripts/UI/MainMenu.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+/// <summary>
+/// Behaviour for the main menu buttons.
+/// </summary>
+public class MainMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+    [SerializeField] private GameManager m_gameManager;
+
+    public void Play()
+    {
+        m_gameManager?.StartRun();
+    }
+
+    public void OpenShop()
+    {
+        m_ui?.OpenShop();
+    }
+
+    public void OpenCharacterSelect()
+    {
+        m_ui?.OpenCharacterSelect();
+    }
+
+    public void OpenSettings()
+    {
+        m_ui?.OpenSettings();
+    }
+}

--- a/Assets/_Game/Scripts/UI/PauseMenu.cs
+++ b/Assets/_Game/Scripts/UI/PauseMenu.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+/// <summary>
+/// Behaviour for the pause menu.
+/// </summary>
+public class PauseMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+    [SerializeField] private GameManager m_gameManager;
+
+    public void Resume()
+    {
+        m_ui?.ResumeGame();
+    }
+
+    public void QuitToMenu()
+    {
+        m_gameManager?.EndRun();
+        m_ui?.ShowMainMenu();
+    }
+}

--- a/Assets/_Game/Scripts/UI/RunSummaryMenu.cs
+++ b/Assets/_Game/Scripts/UI/RunSummaryMenu.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+/// <summary>
+/// Behaviour for the post-run summary menu.
+/// </summary>
+public class RunSummaryMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+    [SerializeField] private GameManager m_gameManager;
+
+    public void PlayAgain()
+    {
+        m_gameManager?.StartRun();
+    }
+
+    public void MainMenu()
+    {
+        m_ui?.ShowMainMenu();
+    }
+}

--- a/Assets/_Game/Scripts/UI/SettingsMenu.cs
+++ b/Assets/_Game/Scripts/UI/SettingsMenu.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Behaviour for the settings menu.
+/// </summary>
+public class SettingsMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+
+    public void Back()
+    {
+        m_ui?.ShowMainMenu();
+    }
+}

--- a/Assets/_Game/Scripts/UI/ShopMenu.cs
+++ b/Assets/_Game/Scripts/UI/ShopMenu.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Behaviour for the in-game shop menu.
+/// </summary>
+public class ShopMenu : MonoBehaviour
+{
+    [SerializeField] private UIManager m_ui;
+
+    public void Back()
+    {
+        m_ui?.ShowMainMenu();
+    }
+}

--- a/Assets/_Game/Scripts/UI/UIManager.cs
+++ b/Assets/_Game/Scripts/UI/UIManager.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+
+/// <summary>
+/// Central controller for UI menus and HUD visibility.
+/// </summary>
+public class UIManager : MonoBehaviour
+{
+    [Header("Managers")]
+    [SerializeField] private GameManager m_gameManager;
+    [SerializeField] private AdsManager m_adsManager;
+    [SerializeField] private HUDController m_hud;
+
+    [Header("Player")]
+    [SerializeField] private Health m_playerHealth;
+    [SerializeField] private BuffController m_playerBuffs;
+
+    [Header("Menus")]
+    [SerializeField] private GameObject m_mainMenu;
+    [SerializeField] private GameObject m_pauseMenu;
+    [SerializeField] private GameObject m_runSummaryMenu;
+    [SerializeField] private GameObject m_shopMenu;
+    [SerializeField] private GameObject m_characterSelectMenu;
+    [SerializeField] private GameObject m_settingsMenu;
+
+    private void OnEnable()
+    {
+        if (m_gameManager != null)
+        {
+            m_gameManager.OnRunStarted += HandleRunStarted;
+            m_gameManager.OnRunEnded += HandleRunEnded;
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (m_gameManager != null)
+        {
+            m_gameManager.OnRunStarted -= HandleRunStarted;
+            m_gameManager.OnRunEnded -= HandleRunEnded;
+        }
+    }
+
+    private void Start()
+    {
+        if (m_hud != null)
+            m_hud.Bind(m_gameManager, m_playerHealth, m_playerBuffs);
+        ShowMainMenu();
+    }
+
+    private void HandleRunStarted()
+    {
+        HideAllMenus();
+        if (m_hud != null)
+            m_hud.gameObject.SetActive(true);
+        m_adsManager?.HideBanner();
+    }
+
+    private void HandleRunEnded()
+    {
+        ShowRunSummary();
+    }
+
+    private void HideAllMenus()
+    {
+        if (m_hud != null)
+            m_hud.gameObject.SetActive(false);
+        m_mainMenu?.SetActive(false);
+        m_pauseMenu?.SetActive(false);
+        m_runSummaryMenu?.SetActive(false);
+        m_shopMenu?.SetActive(false);
+        m_characterSelectMenu?.SetActive(false);
+        m_settingsMenu?.SetActive(false);
+    }
+
+    public void ShowMainMenu()
+    {
+        HideAllMenus();
+        m_mainMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+
+    public void ShowRunSummary()
+    {
+        HideAllMenus();
+        m_runSummaryMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+
+    public void PauseGame()
+    {
+        if (m_gameManager == null) return;
+        m_gameManager.Pause();
+        HideAllMenus();
+        m_pauseMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+
+    public void ResumeGame()
+    {
+        if (m_gameManager == null) return;
+        m_gameManager.Resume();
+        HideAllMenus();
+        if (m_hud != null)
+            m_hud.gameObject.SetActive(true);
+        m_adsManager?.HideBanner();
+    }
+
+    public void OpenShop()
+    {
+        HideAllMenus();
+        m_shopMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+
+    public void OpenCharacterSelect()
+    {
+        HideAllMenus();
+        m_characterSelectMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+
+    public void OpenSettings()
+    {
+        HideAllMenus();
+        m_settingsMenu?.SetActive(true);
+        m_adsManager?.ShowBanner();
+    }
+}


### PR DESCRIPTION
## Summary
- Add HUD controller to display health, coins, score, combo, and buff timers
- Implement UI manager and menu scripts for main, pause, run summary, shop, character select, and settings menus
- Extend GameManager with coin/combo tracking and pause controls while hooking UI and ads

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a752e726548330b96b6543c2bf39b4