### PR TITLE
Enhance ad policy and adapters

### DIFF
--- a/Assets/_Game/Scripts/Ads/Adapters/AdmobAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/AdmobAdapter.cs
@@ -12,8 +12,11 @@ public class AdmobAdapter : IAdNetworkAdapter
     public event Action OnAdClosed;
     public event Action OnAdRewarded;
 
-    public bool IsInterstitialReady => false;
-    public bool IsRewardedReady => false;
+    private bool m_interstitialReady;
+    private bool m_rewardedReady;
+
+    public bool IsInterstitialReady => m_interstitialReady;
+    public bool IsRewardedReady => m_rewardedReady;
 
     public void Initialize(ConsentState consent)
     {
@@ -23,21 +26,42 @@ public class AdmobAdapter : IAdNetworkAdapter
     public void LoadInterstitial()
     {
         Debug.Log("[Admob] Load interstitial");
+        m_interstitialReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowInterstitial()
     {
+        if (!m_interstitialReady)
+        {
+            OnAdFailed?.Invoke("Interstitial not ready");
+            return;
+        }
         Debug.Log("[Admob] Show interstitial");
+        m_interstitialReady = false;
+        OnAdShown?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void LoadRewarded()
     {
         Debug.Log("[Admob] Load rewarded");
+        m_rewardedReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowRewarded()
     {
+        if (!m_rewardedReady)
+        {
+            OnAdFailed?.Invoke("Rewarded not ready");
+            return;
+        }
         Debug.Log("[Admob] Show rewarded");
+        m_rewardedReady = false;
+        OnAdShown?.Invoke();
+        OnAdRewarded?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void ShowBanner()

--- a/Assets/_Game/Scripts/Ads/Adapters/LevelPlayAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/LevelPlayAdapter.cs
@@ -12,8 +12,11 @@ public class LevelPlayAdapter : IAdNetworkAdapter
     public event Action OnAdClosed;
     public event Action OnAdRewarded;
 
-    public bool IsInterstitialReady => false;
-    public bool IsRewardedReady => false;
+    private bool m_interstitialReady;
+    private bool m_rewardedReady;
+
+    public bool IsInterstitialReady => m_interstitialReady;
+    public bool IsRewardedReady => m_rewardedReady;
 
     public void Initialize(ConsentState consent)
     {
@@ -23,21 +26,42 @@ public class LevelPlayAdapter : IAdNetworkAdapter
     public void LoadInterstitial()
     {
         Debug.Log("[LevelPlay] Load interstitial");
+        m_interstitialReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowInterstitial()
     {
+        if (!m_interstitialReady)
+        {
+            OnAdFailed?.Invoke("Interstitial not ready");
+            return;
+        }
         Debug.Log("[LevelPlay] Show interstitial");
+        m_interstitialReady = false;
+        OnAdShown?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void LoadRewarded()
     {
         Debug.Log("[LevelPlay] Load rewarded");
+        m_rewardedReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowRewarded()
     {
+        if (!m_rewardedReady)
+        {
+            OnAdFailed?.Invoke("Rewarded not ready");
+            return;
+        }
         Debug.Log("[LevelPlay] Show rewarded");
+        m_rewardedReady = false;
+        OnAdShown?.Invoke();
+        OnAdRewarded?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void ShowBanner()

--- a/Assets/_Game/Scripts/Ads/Adapters/UnityMediationAdapter.cs
+++ b/Assets/_Game/Scripts/Ads/Adapters/UnityMediationAdapter.cs
@@ -12,8 +12,11 @@ public class UnityMediationAdapter : IAdNetworkAdapter
     public event Action OnAdClosed;
     public event Action OnAdRewarded;
 
-    public bool IsInterstitialReady => false;
-    public bool IsRewardedReady => false;
+    private bool m_interstitialReady;
+    private bool m_rewardedReady;
+
+    public bool IsInterstitialReady => m_interstitialReady;
+    public bool IsRewardedReady => m_rewardedReady;
 
     public void Initialize(ConsentState consent)
     {
@@ -23,21 +26,42 @@ public class UnityMediationAdapter : IAdNetworkAdapter
     public void LoadInterstitial()
     {
         Debug.Log("[UnityMediation] Load interstitial");
+        m_interstitialReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowInterstitial()
     {
+        if (!m_interstitialReady)
+        {
+            OnAdFailed?.Invoke("Interstitial not ready");
+            return;
+        }
         Debug.Log("[UnityMediation] Show interstitial");
+        m_interstitialReady = false;
+        OnAdShown?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void LoadRewarded()
     {
         Debug.Log("[UnityMediation] Load rewarded");
+        m_rewardedReady = true;
+        OnAdLoaded?.Invoke();
     }
 
     public void ShowRewarded()
     {
+        if (!m_rewardedReady)
+        {
+            OnAdFailed?.Invoke("Rewarded not ready");
+            return;
+        }
         Debug.Log("[UnityMediation] Show rewarded");
+        m_rewardedReady = false;
+        OnAdShown?.Invoke();
+        OnAdRewarded?.Invoke();
+        OnAdClosed?.Invoke();
     }
 
     public void ShowBanner()

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It demonstrates an extensible architecture using ScriptableObjects, object pooli
 and an ad mediation layer via `AdsManager` and pluggable `IAdNetworkAdapter` implementations.
 Core gameplay scaffolding is provided including managers, player components and utilities.
 The skeleton also includes a persistent save system and configurable ad policy for frequency-capped interstitial and rewarded ads.
+Ad policy now supports consent-gated operation, ad-free purchase disabling, and run/session tracking for timestamp-based caps.
 
 Project structure:
 


### PR DESCRIPTION
## Summary
- Expand `AdPolicy` with consent gating and ad-free flag
- Track run counts and ad timestamps in `AdsManager`
- Flesh out AdMob, Unity Mediation, and LevelPlay adapter stubs

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a759fb61508330a9990c550ee6f540