### PR TITLE
Add Git LFS tracking for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Core gameplay scaffolding is provided including managers, player components and 
 The skeleton also includes a persistent save system and configurable ad policy for frequency-capped interstitial and rewarded ads.
 Ad policy now supports consent-gated operation, ad-free purchase disabling, and run/session tracking for timestamp-based caps.
 
+## Setup
+
+This project stores image and audio assets using [Git LFS](https://git-lfs.com/). Install Git LFS before cloning so these files download correctly.
+
 Project structure:
 
 ```


### PR DESCRIPTION
## Summary
- Track PNG and WAV assets in Git LFS
- Re-normalize repository so assets use LFS
- Document Git LFS requirement in README

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a75c92701883308bfb29ed34527fc5