### PR TITLE
Add extensible save data schema with ads and shop integration

### DIFF
--- a/Assets/_Game/Scripts/UI/ShopMenu.cs
+++ b/Assets/_Game/Scripts/UI/ShopMenu.cs
@@ -6,6 +6,30 @@ using UnityEngine;
 public class ShopMenu : MonoBehaviour
 {
     [SerializeField] private UIManager m_ui;
+    [SerializeField] private SaveSystem m_saveSystem;
+
+    private void Awake()
+    {
+        m_saveSystem?.Load();
+    }
+
+    public void UnlockCharacter(string id)
+    {
+        if (m_saveSystem != null && !m_saveSystem.IsCharacterUnlocked(id))
+        {
+            m_saveSystem.UnlockCharacter(id);
+            m_saveSystem.Save();
+        }
+    }
+
+    public void PurchaseUpgrade(string id)
+    {
+        if (m_saveSystem != null && !m_saveSystem.HasUpgrade(id))
+        {
+            m_saveSystem.PurchaseUpgrade(id);
+            m_saveSystem.Save();
+        }
+    }
 
     public void Back()
     {


### PR DESCRIPTION
## Summary
- expand `SaveSystem` with versioned save data including unlocked characters, upgrades, settings, and ad counters
- use `SaveSystem` inside `AdsManager` to persist run counts and ad timestamps
- hook `ShopMenu` into `SaveSystem` for unlocking characters and purchasing upgrades

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a75da71b08833081b7164861603b9f